### PR TITLE
updated obsolete/deprecated UnityAPI call

### DIFF
--- a/Assets/Common/Editor/ReplaceFont.cs
+++ b/Assets/Common/Editor/ReplaceFont.cs
@@ -302,7 +302,7 @@ namespace Plugins
             var currentScene = EditorSceneManager.GetActiveScene().path;
             EditorSceneManager.SaveCurrentModifiedScenesIfUserWantsTo();
 
-            var textComponents = Component.FindObjectsOfType<Text>();
+            var textComponents = Component.FindObjectsByType<Text>(FindObjectsSortMode.None);
 
             foreach (string scene in scenesPaths)
             {


### PR DESCRIPTION
Component.FindObjectsOfType<>() isn't supported anymore, changed it to new method Component.FindObjectsByType<>() with no sorting as an UUID-sorted list isn't neccessary here